### PR TITLE
Add info about using X11 in the docker.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ You are directly connected to the container.
 
 Note you can also share a directory with your host using `-v hostdir:containerdir`.
 
+If you try to use any graphical interface and get an error like `No protocol specified` followed by an crash (`SEGFAULT`), using this command before running the docker should fix it: `xhost +local:docker`.
+
 **IMPORTANT**: if you want to use the Android emulator x86 image, you need to set the `--privileged` option in the command line, i.e:
 
 ```


### PR DESCRIPTION
I was having crashes when using it with the given instuctions, using the given command:

`docker run -it --privileged --rm -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix cryptax/android-re:latest /bin/bash `

Searching around I found this fix and I think others users may have the same issue, so I worth putting it here.