### PR TITLE
Add pyaxmlparser to RE tools

### DIFF
--- a/Dockerfile.re
+++ b/Dockerfile.re
@@ -174,6 +174,9 @@ RUN pip3 install apkleaks
 # apkleaks requires jadx to be on the path
 ENV PATH $PATH:/opt/jadx/jadx/bin
 
+# pyaxml parser which will install a commandline apkinfo to quickly display info about APK
+RUN pip3 install pyaxmlparser
+
 
 # ------------------------ Install SSH access ---------------------------------------------
  RUN mkdir /var/run/sshd \


### PR DESCRIPTION
pyaxmlparser also offers a commandline tool `apkinfo` which provides quick way of showing the properties of APK.

Sample code output:

```
    $ apkinfo ~/Downloads/com.hardcodedjoy.roboremo.15.apk
    APK: /home/chillaranand/Downloads/com.hardcodedjoy.roboremo.15.apk
    App name: RoboRemo
    Package: com.hardcodedjoy.roboremo
    Version name: 2.0.0
    Version code: 15
    Is it Signed: True
    Is it Signed with v1 Signatures: True
    Is it Signed with v2 Signatures: True
    Is it Signed with v3 Signatures: False
```